### PR TITLE
Move ssh passphrase to Secrets.swift

### DIFF
--- a/Sources/InitCommand.swift
+++ b/Sources/InitCommand.swift
@@ -57,6 +57,9 @@ class InitCommand: FlockCommand {
         try write(contents: packageDefault(), to: Path.flockPackageFile)
         
         try formFlockDirectory()
+
+        try write(contents: secretsDefault(), to: Path.secretsFile)
+
         try linkFilesIntoFlock()
         
         print("Successfully created Flock files".green)
@@ -84,6 +87,7 @@ class InitCommand: FlockCommand {
             "",
             "# Flock",
             Path.flockDirectory.description,
+            "\(Path.flockDirectory.description)/Secrets.swift",
             ""
         ].joined(separator: "\n")
         
@@ -166,12 +170,22 @@ class InitCommand: FlockCommand {
     
     private func envConfigDefaults() -> [String] {
       return [
-            "// Config.SSHAuthMethod = SSH.Key(",
-            "//     privateKey: \"~/.ssh/key\",",
-            "//     passphrase: \"passphrase\"",
-            "// )",
+            "// Config.SSHAuthMethod = Secrets.key",
             "// Flock.serve(ip: \"9.9.9.9\", user: \"user\", roles: [.app, .db, .web])"
       ]
+    }
+
+    private func secretsDefault() -> String {
+        return [
+            "import Shout",
+            "",
+            "internal class Secrets {",
+            "    static internal let key: SSH.Key = SSH.Key(",
+            "        privateKey: \"~/.ssh/key\",",
+            "        passphrase: \"passphrase\"",
+            "    )",
+            "}"
+        ].joined(separator: "\n")
     }
     
     private func baseDefaults() -> [String] {

--- a/Sources/InitCommand.swift
+++ b/Sources/InitCommand.swift
@@ -121,7 +121,7 @@ class InitCommand: FlockCommand {
         
         var lines = [
             "import Flock",
-            "import SSH",
+            "import Shout",
             "",
             "class \(env.capitalized): Environment {",
             "\tfunc configure() {"

--- a/Sources/Paths.swift
+++ b/Sources/Paths.swift
@@ -15,6 +15,7 @@ extension Path {
     
     static let flockDirectory = Path(".flock")
     static let packageFile = flockDirectory + "Package.swift"
+    static let secretsFile = flockDirectory + "Secrets.swift"
     static let mainFile = flockDirectory + "main.swift"
     
     static let buildDirectory = flockDirectory + ".build"


### PR DESCRIPTION
In the previous configuration, the ssh key passphrase was commited to the repository by default (which I accidentally did while raging `git add .` `git commit -m 'fix'` '`git push`.) I had to change my passhprase after that ;)

I've created a private `Secrets.swift` file in `.flock` directory, which is in `.gitignore` by default, so passphrases are not stored in the repository.

Also, the dependencies were outdated in the default files.
